### PR TITLE
fix: Correcting none type handling

### DIFF
--- a/multi_anonymizer.py
+++ b/multi_anonymizer.py
@@ -199,7 +199,7 @@ def anonymize_value(selector: Selector, original_value, context: Dict[str, str] 
             value_to_anonymize = match.group(1)
 
     # empty values should stay empty:
-    anonymized_value = get_fake_dict(selector)[value_to_anonymize] if isNumber or len(original_value) > 0 else ''
+    anonymized_value = get_fake_dict(selector)[value_to_anonymize] if not None or isNumber or len(original_value) > 0 else ''
 
     if not isNumber and selector.regexp is not None:
         anonymized_value = search_and_replace_dynamic(original_value, selector.regexp, anonymized_value)


### PR DESCRIPTION
Resolves this error with nodes without content ,e.g. `<Strasse></Strasse>` via `python3 multi_anonymizer.py -t xml -i "input/my.xml:(type=street,xpath=//Strasse)"`

```
Traceback (most recent call last):
  File "//multi_anonymizer.py", line 636, in <module>
All anonymizations:
input 'Source: input/my.xml, Sub Source: None':
  selector: Selector[data_type='street', input_type='xml', path='//Strasse', template='{{__value__}}']
Processing 'input/my.xml' with the selectors:
  Selector[data_type='street', input_type='xml', path='//Strasse', template='{{__value__}}']
anonymizing file input/diwa4/src/test/resources/DiWa_TransferListe_2.xml selector Selector[data_type='street', input_type='xml', path='//Strasse', template='{{__value__}}'] to file input/my.xml_anonymized
    counter = anonymize_xml(source.name, target, selectors, ARGS.encoding, namespaces)
  File "//multi_anonymizer.py", line 318, in anonymize_xml
    element.text = str(anonymize_value(selector, element.text, context))
  File "//multi_anonymizer.py", line 202, in anonymize_value
    anonymized_value = get_fake_dict(selector)[value_to_anonymize] if None or isNumber or len(original_value) > 0 else ''
TypeError: object of type 'NoneType' has no len()

```